### PR TITLE
Updated Python < 3.6 versions used by pyenv.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ RUN curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/py
 ENV PYENV_ROOT /root/.pyenv
 ENV PATH /root/.pyenv/shims:/root/.pyenv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-RUN pyenv install 2.7.10
-RUN pyenv install 3.3.6
-RUN pyenv install 3.4.6
-RUN pyenv install 3.5.3
+RUN pyenv install 2.7.14
+RUN pyenv install 3.3.7
+RUN pyenv install 3.4.7
+RUN pyenv install 3.5.4
 
 # Activate all installed Pythons
 RUN pyenv global system $(ls ~/.pyenv/versions/)


### PR DESCRIPTION
Update minor releases of Python 2.7 - 3.5 per https://www.python.org/downloads/ as of now (Nov 28 2017)